### PR TITLE
暫定OS X対応、エディタ環境による動作切り分け、エラーメッセージ対処

### DIFF
--- a/GameWindowMover.cs
+++ b/GameWindowMover.cs
@@ -34,18 +34,18 @@ public class GameWindowMover : EditorWindow
 	private bool toggle = true;
 	
 	//Get the size of the window borders. Changes depending on the OS.
-	#if UNITY_STANDALONE_WIN
+	#if UNITY_EDITOR_WIN
 	//Windows settings
 	private int osBorderWidth = 5;
-	#elif UNITY_STANDALONE_OSX
+	#elif UNITY_EDITOR_OSX
 	//Mac settings (untested)
 	private int osBorderWidth = 0; //OSX windows are borderless.
 	#else
 	//Linux / other platform; sizes change depending on the variant you're running
 	private int osBorderWidth = 5;
 	#endif
-	//default setting 
-	private static Vector2 gameSizeDK1 = new Vector2(1280, 800); // Oculus Rift DK1 resolution
+
+	//private static Vector2 gameSizeDK1 = new Vector2(1280, 800); // Oculus Rift DK1 resolution
 	private static Vector2 gameSizeDK2 = new Vector2(1920, 1080); // Oculus Rift DK2 resolution
 
 	//Desired window resolution
@@ -67,7 +67,7 @@ public class GameWindowMover : EditorWindow
 	// add for win32 api to get display resolution
 	// ---------------------------------------------------------------------------------------------------
 	// resolutions list exclude main monitor
-#if UNITY_STANDALONE_WIN
+#if UNITY_EDITOR_WIN
 	private List<RectApi> screenInfo;
 	
 	delegate bool MonitorEnumProc(IntPtr hMonitor, IntPtr hdc, ref RectApi pRect, int dwData);
@@ -135,7 +135,7 @@ public class GameWindowMover : EditorWindow
 	// ---------------------------------------------------------------------------------------------------
 	// end win32 api
 	// ---------------------------------------------------------------------------------------------------
-#elif UNITY_STANDALONE_OSX
+#elif UNITY_EDITOR_OSX
 	void SetDefault(bool flg)
 	{
 		if (flg || gameSize.x == 0) {
@@ -161,7 +161,11 @@ public class GameWindowMover : EditorWindow
 		Vector2 popupSize = new Vector2(300, 140);
 		//When minSize and maxSize are the same, no OS border is applied to the window.
 		window.minSize = popupSize;
+#if UNITY_EDITOR_OSX
+		window.maxSize = popupSize + new Vector2(0, 1); // make popup window draggable for OSX
+#else
 		window.maxSize = popupSize;
+#endif
 		window.title = "RiftMode";
 		window.ShowPopup();
 	}
@@ -181,7 +185,6 @@ public class GameWindowMover : EditorWindow
 	void OnGUI()
 	{
 #if UNITY_EDITOR
-		
 		EditorGUILayout.Space();
 		
 		if (useDesktopResolution)
@@ -215,7 +218,6 @@ public class GameWindowMover : EditorWindow
 			}
 			else
 			{
-				CloseGameWindow();
 				toggle = false;
 			}
 		}

--- a/GameWindowMover.cs
+++ b/GameWindowMover.cs
@@ -45,14 +45,14 @@ public class GameWindowMover : EditorWindow
 	private int osBorderWidth = 5;
 	#endif
 	//default setting 
-	private static Vector2 _gameSize = new Vector2(0, 0); //window positon init size
-	private static Vector2 _gamePosition = new Vector2(0, 0);
-	
+	private static Vector2 gameSizeDK1 = new Vector2(1280, 800); // Oculus Rift DK1 resolution
+	private static Vector2 gameSizeDK2 = new Vector2(1920, 1080); // Oculus Rift DK2 resolution
+
 	//Desired window resolution
-	public Vector2 gameSize = new Vector2(_gameSize.x, _gameSize.y);
+	public Vector2 gameSize = new Vector2(0, 0);
 	
 	//Desired window position
-	public Vector2 gamePosition = new Vector2(_gamePosition.x, _gamePosition.y);
+	public Vector2 gamePosition = new Vector2(0, 0);
 	
 	//Tells the script to use the default resolution specified in the player settings.
 	//private bool usePlayerSettingsResolution = false;
@@ -67,6 +67,7 @@ public class GameWindowMover : EditorWindow
 	// add for win32 api to get display resolution
 	// ---------------------------------------------------------------------------------------------------
 	// resolutions list exclude main monitor
+#if UNITY_STANDALONE_WIN
 	private List<RectApi> screenInfo;
 	
 	delegate bool MonitorEnumProc(IntPtr hMonitor, IntPtr hdc, ref RectApi pRect, int dwData);
@@ -116,11 +117,6 @@ public class GameWindowMover : EditorWindow
 		return true;
 	}
 	
-	void Awake()
-	{
-		SetDefault(false);
-	}
-	
 	void SetDefault(bool flg)
 	{
 		screenInfo = new List<RectApi>();
@@ -139,6 +135,21 @@ public class GameWindowMover : EditorWindow
 	// ---------------------------------------------------------------------------------------------------
 	// end win32 api
 	// ---------------------------------------------------------------------------------------------------
+#elif UNITY_STANDALONE_OSX
+	void SetDefault(bool flg)
+	{
+		if (flg || gameSize.x == 0) {
+			Resolution reso = UnityEngine.Screen.currentResolution;
+			gameSize = gameSizeDK2;
+			gamePosition = new Vector2(reso.width, 0);
+		}
+	}
+#endif
+
+	void Awake()
+	{
+		SetDefault(false);
+	}
 
 #endif
 	//Shows the popup


### PR DESCRIPTION
Macで動かなくなっていたので調整してみましたがいかがでしょう。
Winでの動作は影響ないようにしたつもりですが未確認ですすみませんm(__)m

・Mac OS X でそれなりに動くようにしました。
・ビルドターゲットによる環境切り分けになっていたので、エディタの実行環境による切り分けに変更しました。
・GameViewがDockされている場合？にCloseGameWindow()を実行すると以下のようなエラーが山のように出るので、開始時のCloseGameWindow()をしないようにしました。

```
NullReferenceException: Object reference not set to an instance of an object
UnityEditor.EditorWindow.SetInternalGameViewRect (Rect rect) (at /Users/builduser/buildslave/unity/build/artifacts/generated/common/editor/EditorWindow.gen.cs:708)
UnityEditor.GameView.GameViewAspectWasChanged () (at /Users/builduser/buildslave/unity/build/Editor/Mono/GameView/GameView.cs:136)
UnityEditor.GameView.DoDelayedGameViewChanged () (at /Users/builduser/buildslave/unity/build/Editor/Mono/GameView/GameView.cs:168)
UnityEditor.EditorApplication.Internal_CallUpdateFunctions () (at /Users/builduser/buildslave/unity/build/artifacts/generated/common/editor/EditorApplication.gen.cs:268)
```
